### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ in `config/application.rb`:
 ```ruby
 config.middleware.insert_after ActionDispatch::ParamsParser, ActionDispatch::XmlParamsParser
 ```
+
+You may need to require the `ActionDispatch::XmlParamsParser` manually. Add the following 
+in your `config/application.rb`:
+
+```ruby
+require 'action_dispatch/xml_params_parser'
+```


### PR DESCRIPTION
When deploying a Rails 4.1 app it would fail on any `rake` task, unless I used the `bundle exec` command. 

This meant that Pushion Passenger tried to start the server it gave me the error: `uninitialized constant ActionDispatch::XmlParamsParser`

Adding the require fixed the issue.
