### PR TITLE
Update for Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.9
-  - 2.0
-  - 2.1
   - 2.2
   - ruby-head
 gemfile:
@@ -17,10 +14,3 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
-  exclude:
-    - rvm: 1.9
-      gemfile: gemfiles/Gemfile-edge
-    - rvm: 2.0
-      gemfile: gemfiles/Gemfile-edge
-    - rvm: 2.1
-      gemfile: gemfiles/Gemfile-edge

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
 gemspec
+gem 'actionpack', github: 'rails/rails'
+gem 'rack', github: 'rack/rack'

--- a/actionpack-xml_parser.gemspec
+++ b/actionpack-xml_parser.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'actionpack-xml_parser'
-  s.version     = '1.0.2'
+  s.version     = '2.0.0'
   s.summary     = 'XML parameters parser for Action Pack (removed from core in Rails 4.0)'
 
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.2.2'
   s.license     = 'MIT'
 
   s.author      = 'Prem Sichanugrist'

--- a/actionpack-xml_parser.gemspec
+++ b/actionpack-xml_parser.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = %w( README.md )
   s.rdoc_options.concat ['--main',  'README.md']
 
-  s.add_dependency('actionpack', '>= 4.0.0', '< 5')
+  s.add_dependency('actionpack', '~> 5.x')
 
   s.add_development_dependency('rake')
 end

--- a/gemfiles/Gemfile-edge
+++ b/gemfiles/Gemfile-edge
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'actionpack', github: 'rails/rails', branch: 'master'
+gem 'rack', github: 'rack/rack', branch: 'master'

--- a/lib/action_dispatch/xml_params_parser.rb
+++ b/lib/action_dispatch/xml_params_parser.rb
@@ -26,10 +26,11 @@ module ActionDispatch
           request.content_mime_type
 
         if mime_type == Mime::XML
-          # Rails 4.1 moved #deep_munge out of the request and into ActionDispatch::Request::Utils
+          # Rails 5 removed #deep_munge and replaced it with #normalize_encode_params
           munger = defined?(Request::Utils) ? Request::Utils : request
+          params = Hash.from_xml(request.body.read) || {}
 
-          data = munger.deep_munge(Hash.from_xml(request.body.read) || {})
+          data = munger.normalize_encode_params(params)
           request.body.rewind if request.body.respond_to?(:rewind)
           data.with_indifferent_access
         else

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -35,10 +35,10 @@ class ActionDispatch::IntegrationTest < ActiveSupport::TestCase
 
   def self.build_app(routes = nil)
     RoutedRackApp.new(routes || ActionDispatch::Routing::RouteSet.new) do |middleware|
-      middleware.use "ActionDispatch::ShowExceptions", ActionDispatch::PublicExceptions.new(FIXTURE_LOAD_PATH)
-      middleware.use "ActionDispatch::ParamsParser"
-      middleware.use "ActionDispatch::XmlParamsParser"
-      middleware.use "Rack::Head"
+      middleware.use ActionDispatch::ShowExceptions, ActionDispatch::PublicExceptions.new(FIXTURE_LOAD_PATH)
+      middleware.use ActionDispatch::ParamsParser
+      middleware.use ActionDispatch::XmlParamsParser
+      middleware.use Rack::Head
       yield(middleware) if block_given?
     end
   end

--- a/test/webservice_test.rb
+++ b/test/webservice_test.rb
@@ -4,9 +4,9 @@ class WebServiceTest < ActionDispatch::IntegrationTest
   class TestController < ActionController::Base
     def assign_parameters
       if params[:full]
-        render :text => dump_params_keys
+        render plain: dump_params_keys
       else
-        render :text => (params.keys - ['controller', 'action']).sort.join(", ")
+        render plain: (params.keys - ['controller', 'action']).sort.join(", ")
       end
     end
 

--- a/test/webservice_test.rb
+++ b/test/webservice_test.rb
@@ -13,7 +13,13 @@ class WebServiceTest < ActionDispatch::IntegrationTest
     def dump_params_keys(hash = params)
       hash.keys.sort.inject("") do |s, k|
         value = hash[k]
-        value = Hash === value ? "(#{dump_params_keys(value)})" : ""
+
+        if value.is_a?(Hash) || value.is_a?(ActionController::Parameters)
+          value = "(#{dump_params_keys(value)})"
+        else
+          value = ""
+        end
+
         s << ", " unless s.empty?
         s << "#{k}#{value}"
       end

--- a/test/webservice_test.rb
+++ b/test/webservice_test.rb
@@ -40,8 +40,8 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
   def test_post_xml
     with_test_route_set do
-      post "/", '<entry attributed="true"><summary>content...</summary></entry>',
-        {'CONTENT_TYPE' => 'application/xml'}
+      post "/", params: '<entry attributed="true"><summary>content...</summary></entry>',
+        headers: {'CONTENT_TYPE' => 'application/xml'}
 
       assert_equal 'entry', @controller.response.body
       assert @controller.params.has_key?(:entry)
@@ -52,8 +52,8 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
   def test_put_xml
     with_test_route_set do
-      put "/", '<entry attributed="true"><summary>content...</summary></entry>',
-        {'CONTENT_TYPE' => 'application/xml'}
+      put "/", params: '<entry attributed="true"><summary>content...</summary></entry>',
+        headers: {'CONTENT_TYPE' => 'application/xml'}
 
       assert_equal 'entry', @controller.response.body
       assert @controller.params.has_key?(:entry)
@@ -64,8 +64,8 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
   def test_put_xml_using_a_type_node
     with_test_route_set do
-      put "/", '<type attributed="true"><summary>content...</summary></type>',
-        {'CONTENT_TYPE' => 'application/xml'}
+      put "/", params: '<type attributed="true"><summary>content...</summary></type>',
+        headers: {'CONTENT_TYPE' => 'application/xml'}
 
       assert_equal 'type', @controller.response.body
       assert @controller.params.has_key?(:type)
@@ -76,8 +76,8 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
   def test_put_xml_using_a_type_node_and_attribute
     with_test_route_set do
-      put "/", '<type attributed="true"><summary type="boolean">false</summary></type>',
-        {'CONTENT_TYPE' => 'application/xml'}
+      put "/", params: '<type attributed="true"><summary type="boolean">false</summary></type>',
+        headers: {'CONTENT_TYPE' => 'application/xml'}
 
       assert_equal 'type', @controller.response.body
       assert @controller.params.has_key?(:type)
@@ -88,8 +88,8 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
   def test_post_xml_using_a_type_node
     with_test_route_set do
-      post "/", '<font attributed="true"><type>arial</type></font>',
-        {'CONTENT_TYPE' => 'application/xml'}
+      post "/", params: '<font attributed="true"><type>arial</type></font>',
+        headers: {'CONTENT_TYPE' => 'application/xml'}
 
       assert_equal 'font', @controller.response.body
       assert @controller.params.has_key?(:font)
@@ -100,8 +100,8 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
   def test_post_xml_using_a_root_node_named_type
     with_test_route_set do
-      post "/", '<type type="integer">33</type>',
-        {'CONTENT_TYPE' => 'application/xml'}
+      post "/", params: '<type type="integer">33</type>',
+        headers: {'CONTENT_TYPE' => 'application/xml'}
 
       assert @controller.params.has_key?(:type)
       assert_equal 33, @controller.params['type']
@@ -111,8 +111,8 @@ class WebServiceTest < ActionDispatch::IntegrationTest
   def test_post_xml_using_an_attributted_node_named_type
     with_test_route_set do
       with_params_parsers Mime::XML => Proc.new { |data| Hash.from_xml(data)['request'].with_indifferent_access } do
-        post "/", '<request><type type="string">Arial,12</type><z>3</z></request>',
-          {'CONTENT_TYPE' => 'application/xml'}
+        post "/", params: '<request><type type="string">Arial,12</type><z>3</z></request>',
+          headers: {'CONTENT_TYPE' => 'application/xml'}
 
         assert_equal 'type, z', @controller.response.body
         assert @controller.params.has_key?(:type)
@@ -125,10 +125,10 @@ class WebServiceTest < ActionDispatch::IntegrationTest
   def test_post_xml_using_a_disallowed_type_attribute
     $stderr = StringIO.new
     with_test_route_set do
-      post '/', '<foo type="symbol">value</foo>', 'CONTENT_TYPE' => 'application/xml'
+      post '/', params: '<foo type="symbol">value</foo>', headers: {'CONTENT_TYPE' => 'application/xml'}
       assert_response 400
 
-      post '/', '<foo type="yaml">value</foo>', 'CONTENT_TYPE' => 'application/xml'
+      post '/', params: '<foo type="yaml">value</foo>', headers: {'CONTENT_TYPE' => 'application/xml'}
       assert_response 400
     end
   ensure
@@ -138,8 +138,8 @@ class WebServiceTest < ActionDispatch::IntegrationTest
   def test_register_and_use_xml_simple
     with_test_route_set do
       with_params_parsers Mime::XML => Proc.new { |data| Hash.from_xml(data)['request'].with_indifferent_access } do
-        post "/", '<request><summary>content...</summary><title>SimpleXml</title></request>',
-          {'CONTENT_TYPE' => 'application/xml'}
+        post "/", params: '<request><summary>content...</summary><title>SimpleXml</title></request>',
+          headers: {'CONTENT_TYPE' => 'application/xml'}
 
         assert_equal 'summary, title', @controller.response.body
         assert @controller.params.has_key?(:summary)
@@ -152,15 +152,15 @@ class WebServiceTest < ActionDispatch::IntegrationTest
 
   def test_use_xml_ximple_with_empty_request
     with_test_route_set do
-      assert_nothing_raised { post "/", "", {'CONTENT_TYPE' => 'application/xml'} }
+      assert_nothing_raised { post "/", params: "", headers: {'CONTENT_TYPE' => 'application/xml'} }
       assert_equal '', @controller.response.body
     end
   end
 
   def test_dasherized_keys_as_xml
     with_test_route_set do
-      post "/?full=1", "<first-key>\n<sub-key>...</sub-key>\n</first-key>",
-        {'CONTENT_TYPE' => 'application/xml'}
+      post "/?full=1", params: "<first-key>\n<sub-key>...</sub-key>\n</first-key>",
+        headers: {'CONTENT_TYPE' => 'application/xml'}
       assert_equal 'action, controller, first_key(sub_key), full', @controller.response.body
       assert_equal "...", @controller.params[:first_key][:sub_key]
     end
@@ -181,7 +181,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
           <g type="date">1974-07-25</g>
         </data>
       XML
-      post "/", xml, {'CONTENT_TYPE' => 'application/xml'}
+      post "/", params: xml, headers: {'CONTENT_TYPE' => 'application/xml'}
 
       params = @controller.params
       assert_equal 15, params[:data][:a]
@@ -199,7 +199,7 @@ class WebServiceTest < ActionDispatch::IntegrationTest
       xml = <<-XML
         <data>&lt;foo &quot;bar&apos;s&quot; &amp; friends&gt;</data>
       XML
-      post "/", xml, {'CONTENT_TYPE' => 'application/xml'}
+      post "/", params: xml, headers: {'CONTENT_TYPE' => 'application/xml'}
       assert_equal %(<foo "bar's" & friends>), @controller.params[:data]
     end
   end

--- a/test/xml_params_parsing_test.rb
+++ b/test/xml_params_parsing_test.rb
@@ -35,7 +35,7 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
 
   def assert_parses(expected, xml)
     with_test_routing do
-      post "/parse", xml, default_headers
+      post "/parse", params: xml, headers: default_headers
       assert_response :ok
       assert_equal(expected, TestController.last_request_parameters)
     end
@@ -62,7 +62,7 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
   test "parses hash params" do
     with_test_routing do
       xml = "<person><name>David</name></person>"
-      post "/parse", xml, default_headers
+      post "/parse", params: xml, headers: default_headers
       assert_response :ok
       assert_equal({"person" => {"name" => "David"}}, TestController.last_request_parameters)
     end
@@ -71,7 +71,7 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
   test "parses single file" do
     with_test_routing do
       xml = "<person><name>David</name><avatar type='file' name='me.jpg' content_type='image/jpg'>#{::Base64.encode64('ABC')}</avatar></person>"
-      post "/parse", xml, default_headers
+      post "/parse", params: xml, headers: default_headers
       assert_response :ok
 
       person = TestController.last_request_parameters
@@ -85,7 +85,7 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
     with_test_routing do
       output = StringIO.new
       xml = "<person><name>David</name><avatar type='file' name='me.jpg' content_type='image/jpg'>#{::Base64.encode64('ABC')}</avatar></pineapple>"
-      post "/parse", xml, default_headers.merge('action_dispatch.show_exceptions' => true, 'action_dispatch.logger' => ActiveSupport::Logger.new(output))
+      post "/parse", params: xml, headers: default_headers.merge('action_dispatch.show_exceptions' => true, 'action_dispatch.logger' => ActiveSupport::Logger.new(output))
       assert_response :bad_request
       output.rewind && err = output.read
       assert err =~ /Error occurred while parsing request parameters/
@@ -118,7 +118,7 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
     end_body
 
     with_test_routing do
-      post "/parse", xml, default_headers
+      post "/parse", params: xml, headers: default_headers
       assert_response :ok
     end
 
@@ -137,7 +137,7 @@ class XmlParamsParsingTest < ActionDispatch::IntegrationTest
     xml = "<person><name>Marie</name></person>"
 
     with_test_routing do
-      post "/parse", xml, default_headers
+      post "/parse", params: xml, headers: default_headers
       assert_equal TestController.last_request.body.read, xml
     end
   end
@@ -185,7 +185,7 @@ class RootLessXmlParamsParsingTest < ActionDispatch::IntegrationTest
   test "parses hash params" do
     with_test_routing do
       xml = "<name>David</name>"
-      post "/parse", xml, {'CONTENT_TYPE' => 'application/xml'}
+      post "/parse", params: xml, headers: {'CONTENT_TYPE' => 'application/xml'}
       assert_response :ok
       assert_equal({"name" => "David", "person" => {"name" => "David"}}, TestController.last_request_parameters)
     end


### PR DESCRIPTION
Rails 5 changes a lot and actionpack-xm_parser was not compatible with it.

Following changes were made:
* bumps ActionPack and Rack dependencies
* Replaces `deep_munge` with `normalize_encode_params`
* Updates `#dump_params_keys` method in `webservice_test` to match Rails following rails/rails/pull/20868
* fixes deprecation warnings about keyword arguments, rendering plain text, and passing middleware as strings/symbols

Once Rails 5 is released this should not be pointed at Rails master / Rack master but we at Basecamp need this change to use Rails 5 and this gem together. :smile: