### PR TITLE
Allow Utils to be defined on ActionDispatch::Request on Rails 4.0.x

### DIFF
--- a/lib/action_dispatch/xml_params_parser.rb
+++ b/lib/action_dispatch/xml_params_parser.rb
@@ -27,7 +27,7 @@ module ActionDispatch
 
         if mime_type == Mime::XML
           # Rails 4.1 moved #deep_munge out of the request and into ActionDispatch::Request::Utils
-          munger = defined?(Request::Utils) ? Request::Utils : request
+          munger = defined?(Request::Utils) && Request::Utils.respond_to?(:deep_munge) ? Request::Utils : request
 
           data = munger.deep_munge(Hash.from_xml(request.body.read) || {})
           request.body.rewind if request.body.respond_to?(:rewind)


### PR DESCRIPTION
Somewhere in my Rails 4.0.13 application someone defined an empty Utils module on ActionDispatch::Request.  

To test in the unit tests I was able to in test/helpers.rb modify the following:

``` ruby
module ActionDispatch
  module SharedRoutes
    def before_setup
      @routes = SharedTestRoutes
      super
    end
  end
  if ActionPack.version < Gem::Version.new('4.1')
    class Request < Rack::Request
      class Utils
      end
    end
  end
end
```

I can add the above no problem but it feels slightly over-bearing to assume Utils was defined on ActionDispatch::Request for all tests given ActionPack 4.0.  I can add it if anybody wants.  Or the other way was to create a new file.  I am open to work with whoever to write the appropriate unit test for this if required.
